### PR TITLE
Add feedback listing, retrieval, and voting endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,52 @@ docker-compose down -v
 docker-compose up -d
 # Re-run migrations
 ```
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Health check |
+| `POST` | `/api/feedback` | Create a feedback item |
+| `GET` | `/api/feedback` | List feedback (filters + pagination) |
+| `GET` | `/api/feedback/:id` | Get a single feedback item |
+| `POST` | `/api/feedback/:id/votes` | Vote on a feedback item |
+
+### List feedback
+
+`GET /api/feedback` supports optional query parameters:
+
+- `type` — `bug`, `feature`, or `general`
+- `sentiment` — `neutral`, `positive`, or `negative`
+- `tag` — return items whose tags contain the value
+- `page` (default `1`) and `pageSize` (default `20`, max `100`)
+
+```bash
+curl "http://localhost:8080/api/feedback?type=bug&sentiment=negative&page=1&pageSize=10"
+```
+
+Response shape:
+
+```json
+{
+  "items": [ { "id": 1, "title": "...", "votes": 3 } ],
+  "total": 42,
+  "page": 1,
+  "pageSize": 10
+}
+```
+
+### Vote on feedback
+
+`POST /api/feedback/:id/votes` records a vote and returns the updated item.
+The body is optional — send a `userId` to deduplicate votes per user:
+
+```bash
+# Anonymous vote
+curl -X POST http://localhost:8080/api/feedback/1/votes
+
+# Authenticated vote (409 Conflict on a duplicate)
+curl -X POST http://localhost:8080/api/feedback/1/votes \
+  -H "Content-Type: application/json" \
+  -d '{"userId": 7}'
+```

--- a/app/handlers/feedback.go
+++ b/app/handlers/feedback.go
@@ -1,0 +1,182 @@
+package handlers
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"feedback-agent/app/models/entity"
+	"feedback-agent/app/models/enum"
+	"feedback-agent/app/models/request"
+	"feedback-agent/app/store"
+)
+
+const maxPageSize = 100
+
+// FeedbackHandler exposes the HTTP endpoints for feedback and votes.
+type FeedbackHandler struct {
+	store *store.FeedbackStore
+}
+
+func NewFeedbackHandler(s *store.FeedbackStore) *FeedbackHandler {
+	return &FeedbackHandler{store: s}
+}
+
+// Register mounts all feedback routes on the router.
+func (h *FeedbackHandler) Register(router *gin.Engine) {
+	router.POST("/api/feedback", h.Create)
+	router.GET("/api/feedback", h.List)
+	router.GET("/api/feedback/:id", h.Get)
+	router.POST("/api/feedback/:id/votes", h.Vote)
+}
+
+// Create handles POST /api/feedback.
+func (h *FeedbackHandler) Create(c *gin.Context) {
+	var req request.CreateFeedbackRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	sentiment := enum.SentimentNeutral
+	if req.Sentiment != nil {
+		sentiment = *req.Sentiment
+	}
+
+	feedback, err := h.store.Create(c.Request.Context(), entity.Feedback{
+		Title:          req.Title,
+		Description:    req.Description,
+		Type:           req.Type,
+		Tags:           req.Tags,
+		Sentiment:      sentiment,
+		SentimentScore: req.SentimentScore,
+	})
+	if err != nil {
+		log.Printf("Failed to insert feedback: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create feedback"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, feedback)
+}
+
+// List handles GET /api/feedback with optional type/sentiment/tag filters
+// and page/pageSize pagination.
+func (h *FeedbackHandler) List(c *gin.Context) {
+	var q request.ListFeedbackQuery
+	if err := c.ShouldBindQuery(&q); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	filter, err := buildListFilter(q)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	items, total, err := h.store.List(c.Request.Context(), filter)
+	if err != nil {
+		log.Printf("Failed to list feedback: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list feedback"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"items":    items,
+		"total":    total,
+		"page":     q.Page,
+		"pageSize": filter.Limit,
+	})
+}
+
+// Get handles GET /api/feedback/:id.
+func (h *FeedbackHandler) Get(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id must be a positive integer"})
+		return
+	}
+
+	feedback, err := h.store.GetByID(c.Request.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Feedback not found"})
+		return
+	}
+	if err != nil {
+		log.Printf("Failed to get feedback %d: %v", id, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get feedback"})
+		return
+	}
+
+	c.JSON(http.StatusOK, feedback)
+}
+
+// Vote handles POST /api/feedback/:id/votes and returns the updated
+// feedback item with its new vote count.
+func (h *FeedbackHandler) Vote(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id must be a positive integer"})
+		return
+	}
+
+	// The body is optional: an empty body counts as an anonymous vote.
+	var req request.CreateVoteRequest
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	feedback, err := h.store.AddVote(c.Request.Context(), id, req.UserID)
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": "Feedback not found"})
+	case errors.Is(err, store.ErrDuplicateVote):
+		c.JSON(http.StatusConflict, gin.H{"error": "User has already voted on this feedback"})
+	case err != nil:
+		log.Printf("Failed to add vote for feedback %d: %v", id, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to add vote"})
+	default:
+		c.JSON(http.StatusCreated, feedback)
+	}
+}
+
+// buildListFilter validates and converts the raw query into a store filter.
+func buildListFilter(q request.ListFeedbackQuery) (store.ListFilter, error) {
+	filter := store.ListFilter{Tag: q.Tag}
+
+	if q.Type != "" {
+		var t enum.FeedbackType
+		if err := t.UnmarshalText([]byte(q.Type)); err != nil {
+			return store.ListFilter{}, err
+		}
+		filter.Type = &t
+	}
+	if q.Sentiment != "" {
+		var s enum.Sentiment
+		if err := s.UnmarshalText([]byte(q.Sentiment)); err != nil {
+			return store.ListFilter{}, err
+		}
+		filter.Sentiment = &s
+	}
+
+	if q.Page < 1 {
+		q.Page = 1
+	}
+	if q.PageSize < 1 {
+		q.PageSize = 20
+	}
+	if q.PageSize > maxPageSize {
+		q.PageSize = maxPageSize
+	}
+	filter.Limit = q.PageSize
+	filter.Offset = (q.Page - 1) * q.PageSize
+
+	return filter, nil
+}

--- a/app/main.go
+++ b/app/main.go
@@ -9,11 +9,10 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/lib/pq"
 	_ "github.com/lib/pq"
-	"feedback-agent/app/models/entity"
-	"feedback-agent/app/models/enum"
-	"feedback-agent/app/models/request"
+
+	"feedback-agent/app/handlers"
+	"feedback-agent/app/store"
 )
 
 func main() {
@@ -31,11 +30,12 @@ func main() {
 	// Test the connection with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	
+
 	if err := db.PingContext(ctx); err != nil {
 		log.Fatalf("Failed to ping database: %v", err)
 	}
 	log.Println("Successfully connected to database!")
+
 	// Setup Gin router
 	router := gin.Default()
 
@@ -44,66 +44,13 @@ func main() {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 
-	// Create feedback endpoint
-	router.POST("/api/feedback", createFeedbackHandler(db))
+	// Feedback + votes endpoints
+	feedbackStore := store.NewFeedbackStore(db)
+	handlers.NewFeedbackHandler(feedbackStore).Register(router)
 
 	// Start server
 	log.Println("Starting server on :8080")
 	if err := router.Run(":8080"); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
-	}
-}
-
-func createFeedbackHandler(db *sql.DB) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		var req request.CreateFeedbackRequest
-
-		// Bind JSON request
-		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-
-		// Set default sentiment if not provided
-		sentiment := enum.SentimentNeutral
-		if req.Sentiment != nil {
-			sentiment = *req.Sentiment
-		}
-
-		// Insert into database
-		// Auto-generated: id, votes (defaults to 0), created_at, updated_at
-		query := `
-			INSERT INTO feedback (title, description, type, tags, sentiment, sentiment_score, votes)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
-			RETURNING id, votes, created_at, updated_at
-		`
-
-		var feedback entity.Feedback
-		err := db.QueryRow(
-			query,
-			req.Title,
-			req.Description,
-			int(req.Type),
-			pq.Array(req.Tags), // Convert []string to PostgreSQL array
-			int(sentiment),
-			req.SentimentScore,
-			0, // Votes always start at 0
-		).Scan(&feedback.ID, &feedback.Votes, &feedback.CreatedAt, &feedback.UpdatedAt)
-
-		if err != nil {
-			log.Printf("Failed to insert feedback: %v", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create feedback"})
-			return
-		}
-
-		// Set the input fields
-		feedback.Title = req.Title
-		feedback.Description = req.Description
-		feedback.Type = req.Type
-		feedback.Tags = req.Tags
-		feedback.Sentiment = sentiment
-		feedback.SentimentScore = req.SentimentScore
-
-		c.JSON(http.StatusCreated, feedback)
 	}
 }

--- a/app/models/request/create_vote.go
+++ b/app/models/request/create_vote.go
@@ -1,0 +1,7 @@
+package request
+
+// CreateVoteRequest is the body for POST /api/feedback/:id/votes.
+// UserID is optional: anonymous votes are allowed and are not deduplicated.
+type CreateVoteRequest struct {
+	UserID *int `json:"userId,omitempty"`
+}

--- a/app/models/request/list_feedback.go
+++ b/app/models/request/list_feedback.go
@@ -1,0 +1,12 @@
+package request
+
+// ListFeedbackQuery holds the query parameters accepted by GET /api/feedback.
+// Type, sentiment, and tag are optional filters; page and pageSize control
+// pagination.
+type ListFeedbackQuery struct {
+	Type      string `form:"type"`
+	Sentiment string `form:"sentiment"`
+	Tag       string `form:"tag"`
+	Page      int    `form:"page,default=1"`
+	PageSize  int    `form:"pageSize,default=20"`
+}

--- a/app/store/feedback_store.go
+++ b/app/store/feedback_store.go
@@ -1,0 +1,218 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/lib/pq"
+
+	"feedback-agent/app/models/entity"
+	"feedback-agent/app/models/enum"
+)
+
+// ErrNotFound is returned when a requested row does not exist.
+var ErrNotFound = errors.New("not found")
+
+// ErrDuplicateVote is returned when an authenticated user votes twice
+// on the same feedback item.
+var ErrDuplicateVote = errors.New("duplicate vote")
+
+// FeedbackStore wraps all database access for feedback and votes.
+type FeedbackStore struct {
+	db *sql.DB
+}
+
+func NewFeedbackStore(db *sql.DB) *FeedbackStore {
+	return &FeedbackStore{db: db}
+}
+
+// ListFilter describes the optional filters and pagination for ListFeedback.
+type ListFilter struct {
+	Type      *enum.FeedbackType
+	Sentiment *enum.Sentiment
+	Tag       string
+	Limit     int
+	Offset    int
+}
+
+// Create inserts a new feedback row and fills in the generated fields
+// (ID, Votes, CreatedAt, UpdatedAt) on the returned entity.
+func (s *FeedbackStore) Create(ctx context.Context, f entity.Feedback) (entity.Feedback, error) {
+	const query = `
+		INSERT INTO feedback (title, description, type, tags, sentiment, sentiment_score, votes)
+		VALUES ($1, $2, $3, $4, $5, $6, 0)
+		RETURNING id, votes, created_at, updated_at
+	`
+	err := s.db.QueryRowContext(
+		ctx,
+		query,
+		f.Title,
+		f.Description,
+		int(f.Type),
+		pq.Array(f.Tags),
+		int(f.Sentiment),
+		f.SentimentScore,
+	).Scan(&f.ID, &f.Votes, &f.CreatedAt, &f.UpdatedAt)
+	if err != nil {
+		return entity.Feedback{}, fmt.Errorf("insert feedback: %w", err)
+	}
+	return f, nil
+}
+
+// GetByID returns a single feedback item, or ErrNotFound.
+func (s *FeedbackStore) GetByID(ctx context.Context, id int) (entity.Feedback, error) {
+	const query = `
+		SELECT id, title, description, type, tags, sentiment, sentiment_score, votes, created_at, updated_at
+		FROM feedback
+		WHERE id = $1
+	`
+	f, err := scanFeedback(s.db.QueryRowContext(ctx, query, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return entity.Feedback{}, ErrNotFound
+	}
+	if err != nil {
+		return entity.Feedback{}, fmt.Errorf("get feedback %d: %w", id, err)
+	}
+	return f, nil
+}
+
+// List returns feedback rows matching the filter, newest first, plus the
+// total count of matching rows (ignoring pagination) for pagination UIs.
+func (s *FeedbackStore) List(ctx context.Context, filter ListFilter) ([]entity.Feedback, int, error) {
+	where, args := buildWhere(filter)
+
+	var total int
+	countQuery := "SELECT COUNT(*) FROM feedback" + where
+	if err := s.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count feedback: %w", err)
+	}
+
+	listQuery := fmt.Sprintf(`
+		SELECT id, title, description, type, tags, sentiment, sentiment_score, votes, created_at, updated_at
+		FROM feedback%s
+		ORDER BY created_at DESC, id DESC
+		LIMIT $%d OFFSET $%d
+	`, where, len(args)+1, len(args)+2)
+	args = append(args, filter.Limit, filter.Offset)
+
+	rows, err := s.db.QueryContext(ctx, listQuery, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list feedback: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]entity.Feedback, 0, filter.Limit)
+	for rows.Next() {
+		f, err := scanFeedback(rows)
+		if err != nil {
+			return nil, 0, fmt.Errorf("scan feedback: %w", err)
+		}
+		items = append(items, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate feedback: %w", err)
+	}
+	return items, total, nil
+}
+
+// AddVote records a vote for a feedback item and increments its cached
+// vote counter atomically. userID may be nil for anonymous votes; the
+// partial unique index on (feedback_id, user_id) rejects duplicate votes
+// from the same authenticated user.
+func (s *FeedbackStore) AddVote(ctx context.Context, feedbackID int, userID *int) (entity.Feedback, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return entity.Feedback{}, fmt.Errorf("begin vote tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO votes (feedback_id, user_id) VALUES ($1, $2)`,
+		feedbackID, userID,
+	); err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) {
+			switch pqErr.Code.Name() {
+			case "unique_violation":
+				return entity.Feedback{}, ErrDuplicateVote
+			case "foreign_key_violation":
+				return entity.Feedback{}, ErrNotFound
+			}
+		}
+		return entity.Feedback{}, fmt.Errorf("insert vote: %w", err)
+	}
+
+	const bump = `
+		UPDATE feedback
+		SET votes = votes + 1, updated_at = NOW()
+		WHERE id = $1
+		RETURNING id, title, description, type, tags, sentiment, sentiment_score, votes, created_at, updated_at
+	`
+	f, err := scanFeedback(tx.QueryRowContext(ctx, bump, feedbackID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return entity.Feedback{}, ErrNotFound
+	}
+	if err != nil {
+		return entity.Feedback{}, fmt.Errorf("bump vote count: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return entity.Feedback{}, fmt.Errorf("commit vote tx: %w", err)
+	}
+	return f, nil
+}
+
+// buildWhere assembles the WHERE clause and its positional args for List.
+func buildWhere(filter ListFilter) (string, []any) {
+	var clauses []string
+	var args []any
+
+	if filter.Type != nil {
+		args = append(args, int(*filter.Type))
+		clauses = append(clauses, fmt.Sprintf("type = $%d", len(args)))
+	}
+	if filter.Sentiment != nil {
+		args = append(args, int(*filter.Sentiment))
+		clauses = append(clauses, fmt.Sprintf("sentiment = $%d", len(args)))
+	}
+	if filter.Tag != "" {
+		args = append(args, filter.Tag)
+		clauses = append(clauses, fmt.Sprintf("$%d = ANY(tags)", len(args)))
+	}
+
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return " WHERE " + strings.Join(clauses, " AND "), args
+}
+
+// scanner covers both *sql.Row and *sql.Rows.
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanFeedback(row scanner) (entity.Feedback, error) {
+	var f entity.Feedback
+	var typ, sentiment int
+	err := row.Scan(
+		&f.ID,
+		&f.Title,
+		&f.Description,
+		&typ,
+		pq.Array(&f.Tags),
+		&sentiment,
+		&f.SentimentScore,
+		&f.Votes,
+		&f.CreatedAt,
+		&f.UpdatedAt,
+	)
+	if err != nil {
+		return entity.Feedback{}, err
+	}
+	f.Type = enum.FeedbackType(typ)
+	f.Sentiment = enum.Sentiment(sentiment)
+	return f, nil
+}


### PR DESCRIPTION
## What

Extends the API beyond feedback creation with the read and voting paths, and restructures the app into layers along the way.

### New endpoints
- `GET /api/feedback` — list with optional `type`, `sentiment`, and `tag` filters, plus `page`/`pageSize` pagination (max 100). Returns `{items, total, page, pageSize}`.
- `GET /api/feedback/:id` — single item, 404 when missing.
- `POST /api/feedback/:id/votes` — records a vote in the `votes` table and bumps the cached `feedback.votes` counter in one transaction. Anonymous votes allowed; authenticated duplicates return 409 via the existing partial unique index.

### Refactor
- New `app/store` package owns all SQL (create, get, list, vote) with wrapped errors and `ErrNotFound`/`ErrDuplicateVote` sentinels.
- HTTP handlers moved from `main.go` into `app/handlers`; `main.go` now only wires the DB, store, and routes.
- Enum query filters reuse the existing `UnmarshalText` implementations, so filters accept the same string values the JSON API uses.

### Docs
- README gains an API endpoints section with curl examples.

## Testing
- `go build ./...` and `go vet ./...` pass.
- No behavior change to the existing `POST /api/feedback` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints to create, list, retrieve, and vote on feedback.
  * Added filtering by feedback type, sentiment, and tag.
  * Added pagination with page-size limits and total-result metadata.
  * Added support for anonymous and authenticated voting, including duplicate-vote handling.
  * Added validation and clear responses for invalid requests and missing feedback.

* **Documentation**
  * Added API documentation with endpoint details, filters, pagination, response formats, and voting examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->